### PR TITLE
Backend/Frontend: cambios en procesar expedientes cuando se recibe en ME

### DIFF
--- a/backend/apps/expedientes/api/urls.py
+++ b/backend/apps/expedientes/api/urls.py
@@ -17,6 +17,6 @@ urlpatterns = [
     path('prioridades/', PrioridadListView.as_view(), name="prioridades"),
     path('prioridades/<pk>', PrioridadDetailView.as_view()),
     path('instancias_por_expediente/', ExpedienteInstanciasList.as_view()),
-    path('instancias_por_dependencia/<dependencia>/<estado>/', InstanciasMEList.as_view()),
+    path('last_instancia_mesa_entrada/', InstanciasMEList.as_view()),
     path('instancias_sin_pag/', InstanciasForReportesListView.as_view())
 ]

--- a/backend/apps/expedientes/api/views.py
+++ b/backend/apps/expedientes/api/views.py
@@ -161,7 +161,7 @@ class InstanciasMEList(ListAPIView):
         day = datetime.datetime.now()
         formatedYear = day.strftime("%Y")
         queryset = self.get_queryset()\
-            .filter(dependencia_actual_id__descripcion=kwargs.get('dependencia'), estado_id__descripcion=kwargs.get('estado'), expediente_id__anho=formatedYear)[:1]
+            .filter(dependencia_actual_id__descripcion='Mesa Entrada', estado_id__descripcion='Recibido', expediente_id__anho=formatedYear)[:1]
         filtered_list = self.filter_queryset(queryset)
         serializer = self.get_serializer(filtered_list, many=True)
         return Response(serializer.data)

--- a/frontend/src/services/Instancias.js
+++ b/frontend/src/services/Instancias.js
@@ -112,13 +112,11 @@ class Instancias {
   }
 
   /**
-   * Obtiene la instancia mas reciente
-   * teniendo en cuenta la depedencia, estado
-   * @param {*} dependencia 
-   * @param {*} estado 
+   * Obtiene la instancia con numero de Mesa de entrada mas alto
+   * del año en el que se trabaja
    */
-  getInstanciasPorDepEstAnho(dependencia, estado) {
-    return http.get(`/instancias_por_dependencia/${dependencia}/${estado}/`)
+  getInstanciasPorDepEstAnho() {
+    return http.get(`/last_instancia_mesa_entrada/`)
   }
 
 }


### PR DESCRIPTION
Se divide en 2 funciones el procesamiento, primero se asigna la Fecha de ME y luego en otra funcion se asigna el numero de ME y se cambia el estado del expediente al que corresponde. Con esto se soluciona el funcionamiento erroneo que tenia el sistema cuando era puesto en produccion